### PR TITLE
Fix optimize column loops

### DIFF
--- a/app/templates/optimize.html
+++ b/app/templates/optimize.html
@@ -20,18 +20,14 @@
   <h3>3. Граница на свойства</h3>
   От
   <select id="prop-min">
-    {% for col in materials[0].__table__.columns|map(attribute='key') if col|float(default=0) %}
-      {% if col.isdigit() %}
-        <option value="{{col}}">{{col}}</option>
-      {% endif %}
+    {% for col in prop_columns %}
+      <option value="{{ col }}">{{ col }}</option>
     {% endfor %}
   </select>
   До
   <select id="prop-max">
-    {% for col in materials[0].__table__.columns|map(attribute='key') if col|float(default=0) %}
-      {% if col|float and (col|float >= prop_min) %}
-        <option value="{{col}}">{{col}}</option>
-      {% endif %}
+    {% for col in prop_columns %}
+      <option value="{{ col }}">{{ col }}</option>
     {% endfor %}
   </select>
 


### PR DESCRIPTION
## Summary
- fix Jinja loops on optimize page
- send numeric property columns from route

## Testing
- `python -m py_compile app/routes_optimize.py app/optimize.py`

------
https://chatgpt.com/codex/tasks/task_e_6881fcaf6bb0832881677bcabdaddc21