### PR TITLE
Handle missing target profile and parse numeric column names

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -14,7 +14,11 @@ def optimize_task(self, params):
     params идва от фронтенда и съдържа selected_ids, constraints,
     prop_min, prop_max и target_profile.
     """
-    ids, values, target, prop_cols = load_data(params)
+    try:
+        ids, values, target, prop_cols = load_data(params)
+    except ValueError as exc:
+        return {'error': str(exc)}
+
     out = optimize_combo(values, target)
     if not out:
         return {'error': 'Optimization failed'}
@@ -23,5 +27,6 @@ def optimize_task(self, params):
         'material_ids': ids,
         'weights': weights.tolist(),
         'mse': mse,
-        'prop_columns': prop_cols
+        'prop_columns': prop_cols,
+        'target_profile': target.tolist()
     }

--- a/app/templates/optimize.html
+++ b/app/templates/optimize.html
@@ -4,6 +4,7 @@
 <h1>Оптимизация на рецепта</h1>
 
 <form id="opt-form">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <h3>1. Избери материали</h3>
   {% for m in materials %}
     <label>
@@ -20,23 +21,19 @@
   <h3>3. Граница на свойства</h3>
   От
   <select id="prop-min">
-    {% for col in materials[0].__table__.columns|map(attribute='key') if col|float(default=0) %}
-      {% if col.isdigit() %}
-        <option value="{{col}}">{{col}}</option>
-      {% endif %}
+    {% for col in prop_columns %}
+      <option value="{{ col }}">{{ col }}</option>
     {% endfor %}
   </select>
   До
   <select id="prop-max">
-    {% for col in materials[0].__table__.columns|map(attribute='key') if col|float(default=0) %}
-      {% if col|float and (col|float >= prop_min) %}
-        <option value="{{col}}">{{col}}</option>
-      {% endif %}
+    {% for col in prop_columns %}
+      <option value="{{ col }}">{{ col }}</option>
     {% endfor %}
   </select>
 
   <h3>4. Таргет профил</h3>
-  <!-- Можеш да зареждаш го от отделна БД таблица или поле -->
+  <textarea id="target-profile" rows="2" cols="40" placeholder="0.1,0.2,0.3"></textarea>
 
   <button type="submit">Стартирай</button>
 </form>
@@ -64,14 +61,25 @@
       constraints,
       prop_min: parseFloat(document.getElementById('prop-min').value),
       prop_max: parseFloat(document.getElementById('prop-max').value),
-      target_profile: []  // зареди от допълнителен UI
+      target_profile: document.getElementById('target-profile').value
+          .split(/[,\s]+/).map(parseFloat).filter(n => !isNaN(n))
     };
     fetch('/optimize/start', {
-      method:'POST', headers:{'Content-Type':'application/json'},
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': form.csrf_token.value
+      },
       body: JSON.stringify(params)
     })
     .then(r=>r.json())
-    .then(({job_id})=> poll(job_id));
+    .then(data => {
+      if (data.job_id) {
+        poll(data.job_id);
+      } else if (data.result) {
+        showResult(data.result);
+      }
+    });
   });
 
   function poll(job_id) {
@@ -90,6 +98,10 @@
   }
 
   function showResult(res) {
+    if (res.error) {
+      alert(res.error);
+      return;
+    }
     document.getElementById('pct').textContent='100';
     const text = `\nMSE: ${res.mse.toFixed(6)}\n` + res.material_ids.map((id,i)=>
       `Material ${id}: ${(res.weights[i]*100).toFixed(2)}%`


### PR DESCRIPTION
## Summary
- parse numeric values from column names that include characters like `"` and sort using those numbers
- ensure target profile length matches selected properties and return it in optimization results
- validate target profile on optimize start
- add a textarea for entering a target profile and parse it in JS
- show server errors to the user

## Testing
- `python -m py_compile app/routes_optimize.py app/optimize.py app/tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_6881fcaf6bb0832881677bcabdaddc21