### PR TITLE
Handle missing target profile and parse numeric column names

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,8 +14,6 @@ from flask_bcrypt import Bcrypt
 from flask_wtf import CSRFProtect
 from sqlalchemy import text
 from .config import DB_URI
-from .routes_optimize import bp as optimize_bp
-from . import tasks
 
 # ── Extensions ────────────────────────────────────────────────────────────────
 db            = SQLAlchemy()
@@ -122,6 +120,8 @@ def create_app():
     from .routes_auth      import bp as auth_bp
     from .routes_admin     import bp as admin_bp
     from .routes_materials import bp as materials_bp
+    from .routes_optimize  import bp as optimize_bp
+    from . import tasks  # ensure Celery tasks are registered
 
     app.register_blueprint(auth_bp,      url_prefix="/auth")
     app.register_blueprint(admin_bp,     url_prefix="/admin")

--- a/app/routes_optimize.py
+++ b/app/routes_optimize.py
@@ -2,7 +2,15 @@ from flask import Blueprint, render_template, request, jsonify, session
 from flask_login import login_required, current_user
 from sqlalchemy import MetaData, Table, select
 
+from .optimize import (
+    _is_number,
+    _parse_numeric,
+    MAX_COMBINATIONS,
+    MSE_THRESHOLD,
+)
+
 from .tasks import optimize_task
+from kombu.exceptions import OperationalError
 from . import db
 from celery.result import AsyncResult
 
@@ -18,16 +26,32 @@ def _get_materials_table():
 @bp.route('', methods=['GET'])
 @login_required
 def page_optimize():
+    """Render the optimization page with material data and numeric columns."""
     tbl = _get_materials_table()
     rows = db.session.execute(select(tbl)).mappings().all()
-    return render_template('optimize.html', materials=rows)
+    numeric_cols = [c.key for c in tbl.columns if _is_number(c.key)]
+    numeric_cols.sort(key=lambda x: _parse_numeric(x))
+    return render_template(
+        'optimize.html',
+        materials=rows,
+        prop_columns=numeric_cols,
+        default_max_comb=MAX_COMBINATIONS,
+        default_mse_thr=MSE_THRESHOLD,
+    )
 
 
 @bp.route('/start', methods=['POST'])
 @login_required
 def start():
     params = request.json
-    job = optimize_task.apply_async(args=[params])
+    if not params.get('target_profile'):
+        return jsonify(error='Missing target profile'), 400
+    try:
+        job = optimize_task.apply_async(args=[params])
+    except OperationalError:
+        # Fallback when the Celery broker/backend is unreachable
+        result = optimize_task.run(params)
+        return jsonify(status='SUCCESS', result=result), 200
     return jsonify(job_id=job.id), 202
 
 
@@ -36,6 +60,8 @@ def start():
 def status(job_id):
     job = AsyncResult(job_id, app=optimize_task.app)
     resp = {'status': job.status}
+    if job.status == 'PROGRESS':
+        resp['meta'] = job.info
     if job.ready():
         resp['result'] = job.result
     return jsonify(resp)

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1,5 +1,5 @@
 from celery import Celery
-from .optimize import load_data, optimize_combo
+from .optimize import load_data, optimize_combo, MAX_COMBINATIONS, MSE_THRESHOLD
 
 celery = Celery(
     'hypercon',
@@ -14,14 +14,29 @@ def optimize_task(self, params):
     params идва от фронтенда и съдържа selected_ids, constraints,
     prop_min, prop_max и target_profile.
     """
-    ids, values, target, prop_cols = load_data(params)
-    out = optimize_combo(values, target)
+    max_comb = params.get('max_combinations', MAX_COMBINATIONS)
+    mse_thresh = params.get('mse_threshold', MSE_THRESHOLD)
+
+    try:
+        ids, values, target, prop_cols = load_data(params)
+    except ValueError as exc:
+        return {'error': str(exc)}
+
+    progress = []
+
+    def cb(step, best):
+        self.update_state(state='PROGRESS', meta={'current': step, 'total': max_comb, 'best_mse': best})
+        progress.append({'step': step, 'best_mse': best})
+
+    out = optimize_combo(values, target, max_comb, mse_thresh, progress_cb=cb)
     if not out:
-        return {'error': 'Optimization failed'}
+        return {'error': 'Optimization failed', 'progress': progress}
     mse, weights = out
     return {
         'material_ids': ids,
         'weights': weights.tolist(),
         'mse': mse,
-        'prop_columns': prop_cols
+        'prop_columns': prop_cols,
+        'target_profile': target.tolist(),
+        'progress': progress
     }

--- a/app/templates/optimize.html
+++ b/app/templates/optimize.html
@@ -4,6 +4,7 @@
 <h1>Оптимизация на рецепта</h1>
 
 <form id="opt-form">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <h3>1. Избери материали</h3>
   {% for m in materials %}
     <label>
@@ -20,29 +21,34 @@
   <h3>3. Граница на свойства</h3>
   От
   <select id="prop-min">
-    {% for col in materials[0].__table__.columns|map(attribute='key') if col|float(default=0) %}
-      {% if col.isdigit() %}
-        <option value="{{col}}">{{col}}</option>
-      {% endif %}
+    {% for col in prop_columns %}
+      <option value="{{ col }}">{{ col }}</option>
     {% endfor %}
   </select>
   До
   <select id="prop-max">
-    {% for col in materials[0].__table__.columns|map(attribute='key') if col|float(default=0) %}
-      {% if col|float and (col|float >= prop_min) %}
-        <option value="{{col}}">{{col}}</option>
-      {% endif %}
+    {% for col in prop_columns %}
+      <option value="{{ col }}">{{ col }}</option>
     {% endfor %}
   </select>
 
   <h3>4. Таргет профил</h3>
-  <!-- Можеш да зареждаш го от отделна БД таблица или поле -->
+  <textarea id="target-profile" rows="2" cols="40" placeholder="0.1,0.2,0.3"></textarea>
+
+  <h3>5. Параметри на оптимизацията</h3>
+  <label>MAX_COMBINATIONS
+    <input type="number" id="max-comb" value="{{ default_max_comb }}" min="1">
+  </label>
+  <label>MSE_THRESHOLD
+    <input type="number" id="mse-threshold" step="0.0001" value="{{ default_mse_thr }}">
+  </label>
 
   <button type="submit">Стартирай</button>
 </form>
 
 <div id="progress" style="display:none;">
   Прогрес: <span id="pct">0</span>%
+  Най-добро MSE: <span id="best-mse">-</span>
 </div>
 
 <div id="result" style="display:none;">
@@ -64,33 +70,58 @@
       constraints,
       prop_min: parseFloat(document.getElementById('prop-min').value),
       prop_max: parseFloat(document.getElementById('prop-max').value),
-      target_profile: []  // зареди от допълнителен UI
+      target_profile: document.getElementById('target-profile').value
+          .split(/[,\s]+/).map(parseFloat).filter(n => !isNaN(n)),
+      max_combinations: parseInt(document.getElementById('max-comb').value),
+      mse_threshold: parseFloat(document.getElementById('mse-threshold').value)
     };
     fetch('/optimize/start', {
-      method:'POST', headers:{'Content-Type':'application/json'},
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': form.csrf_token.value
+      },
       body: JSON.stringify(params)
     })
     .then(r=>r.json())
-    .then(({job_id})=> poll(job_id));
+    .then(data => {
+      if (data.job_id) {
+        poll(data.job_id);
+      } else if (data.result) {
+        showResult(data.result);
+      }
+    });
   });
 
   function poll(job_id) {
     document.getElementById('progress').style.display = 'block';
-    const interval = setInterval(()=>
+    const interval = setInterval(() =>
       fetch(`/optimize/status/${job_id}`)
-       .then(r=>r.json())
-       .then(data=>{
-         if (data.status==='SUCCESS') {
-           clearInterval(interval);
-           showResult(data.result);
-         } else {
-           // няма percent, затова просто върти леден индикатор
-         }
-       }), 1000);
+        .then(r => r.json())
+        .then(data => {
+          if (data.status === 'SUCCESS') {
+            clearInterval(interval);
+            showResult(data.result);
+          } else if (data.status === 'PROGRESS' && data.meta) {
+            const pct = Math.round(100 * data.meta.current / data.meta.total);
+            document.getElementById('pct').textContent = pct;
+            document.getElementById('best-mse').textContent = data.meta.best_mse.toFixed(6);
+          } else {
+            document.getElementById('pct').textContent = '...';
+          }
+        }), 1000);
   }
 
   function showResult(res) {
-    document.getElementById('pct').textContent='100';
+    if (res.error) {
+      alert(res.error);
+      return;
+    }
+    document.getElementById('pct').textContent = '100';
+    if (res.progress && res.progress.length) {
+      const last = res.progress[res.progress.length - 1];
+      document.getElementById('best-mse').textContent = last.best_mse.toFixed(6);
+    }
     const text = `\nMSE: ${res.mse.toFixed(6)}\n` + res.material_ids.map((id,i)=>
       `Material ${id}: ${(res.weights[i]*100).toFixed(2)}%`
     ).join('\n');


### PR DESCRIPTION
## Summary
- parse numeric values from column names that include characters like `"` and sort using those numbers
- ensure target profile length matches selected properties and return it in optimization results
- validate target profile on optimize start
- add a textarea for entering a target profile and parse it in JS
- show server errors to the user
- expose MAX_COMBINATIONS and MSE_THRESHOLD inputs and display progress during optimization
- fix circular import when initializing the Flask app

## Testing
- `python -m py_compile app/routes_optimize.py app/optimize.py app/tasks.py app/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6881fcaf6bb0832881677bcabdaddc21