### PR TITLE
Improve optimization progress feedback

### DIFF
--- a/app/optimize.py
+++ b/app/optimize.py
@@ -95,6 +95,7 @@ def optimize_combo(
     mse_threshold: float = MSE_THRESHOLD,
     progress_cb=None,
     constraints=None,
+    cancel_cb=None,
 ):
     """Simple random search optimization.
 
@@ -112,6 +113,9 @@ def optimize_combo(
         Called as ``progress_cb(iteration, best_mse)`` after each step.
     constraints : dict
         Ключ: индекс на материала, стойност: (min, max) ограничения на дяловете.
+    cancel_cb : callable, optional
+        If provided, ``cancel_cb()`` is checked each iteration and stops the
+        search when it returns ``True``.
     """
     n = values.shape[0]
     best_mse = float("inf")
@@ -125,6 +129,8 @@ def optimize_combo(
         return True
 
     for i in range(1, max_iter + 1):
+        if cancel_cb and cancel_cb():
+            break
         w = np.random.dirichlet(np.ones(n))
         if not _satisfies(w):
             continue

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1,11 +1,111 @@
 from celery import Celery
-from .optimize import load_data, optimize_combo, MAX_COMBINATIONS, MSE_THRESHOLD
+from .optimize import (
+    load_data,
+    optimize_combo,
+    MAX_COMBINATIONS,
+    MSE_THRESHOLD,
+)
+from threading import Thread, Event
+import uuid
 
 celery = Celery(
     'hypercon',
     broker='redis://localhost:6379/0',
     backend='redis://localhost:6379/1'
 )
+
+# ------------------ Local fallback job handling ------------------
+
+class _LocalJob:
+    def __init__(self, params):
+        self.id = str(uuid.uuid4())
+        self.params = params
+        self.status = 'PENDING'
+        self.meta = {'current': 0, 'total': params.get('max_combinations', MAX_COMBINATIONS), 'best_mse': None}
+        self.result = None
+        self._cancel = Event()
+        Thread(target=self._run, daemon=True).start()
+
+    def cancel(self):
+        self._cancel.set()
+
+    def _run(self):
+        max_comb = self.params.get('max_combinations', MAX_COMBINATIONS)
+        mse_thresh = self.params.get('mse_threshold', MSE_THRESHOLD)
+        try:
+            ids, values, target, prop_cols, constraints = load_data(self.params)
+        except ValueError as exc:
+            self.status = 'FAILURE'
+            self.result = {'error': str(exc)}
+            return
+
+        progress = []
+
+        def cb(step, best):
+            self.status = 'PROGRESS'
+            self.meta.update(current=step, best_mse=best)
+            progress.append({'step': step, 'best_mse': best})
+
+        out = optimize_combo(
+            values,
+            target,
+            max_comb,
+            mse_thresh,
+            progress_cb=cb,
+            constraints=constraints,
+            cancel_cb=self._cancel.is_set,
+        )
+
+        if self._cancel.is_set():
+            self.status = 'REVOKED'
+            self.result = {'error': 'Cancelled', 'progress': progress}
+            return
+        if not out:
+            self.status = 'FAILURE'
+            self.result = {'error': 'Optimization failed', 'progress': progress}
+            return
+
+        mse, weights = out
+        mixed_profile = (weights @ values).tolist()
+        self.result = {
+            'material_ids': ids,
+            'weights': weights.tolist(),
+            'mse': mse,
+            'prop_columns': prop_cols,
+            'mixed_profile': mixed_profile,
+            'progress': progress,
+        }
+        self.status = 'SUCCESS'
+
+
+_local_jobs = {}
+
+
+def start_local_job(params) -> str:
+    job = _LocalJob(params)
+    _local_jobs[job.id] = job
+    return job.id
+
+
+def local_job_status(job_id):
+    job = _local_jobs.get(job_id)
+    if not job:
+        return None
+    resp = {'status': job.status}
+    if job.status == 'PROGRESS':
+        resp['meta'] = job.meta
+    if job.status in {'SUCCESS', 'FAILURE', 'REVOKED'}:
+        resp['result'] = job.result
+    return resp
+
+
+def cancel_local_job(job_id):
+    job = _local_jobs.get(job_id)
+    if not job:
+        return False
+    job.cancel()
+    return True
+
 
 @celery.task(bind=True)
 def optimize_task(self, params):

--- a/app/templates/optimize.html
+++ b/app/templates/optimize.html
@@ -33,7 +33,7 @@
   </select>
 
   <h3>4. Параметри на оптимизацията</h3>
-  <label>MAX_COMBINATIONS
+  <label>MAX_ITERATIONS
     <input type="number" id="max-comb" value="{{ default_max_comb }}" min="1">
   </label>
   <label>MSE_THRESHOLD


### PR DESCRIPTION
## Summary
- add local task fallback to provide progress updates without Celery
- support cancelling of local jobs
- show job progress for local mode
- rename progress label to `MAX_ITERATIONS`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688224420ef48328ac72030526ca3c90