### PR TITLE
Improve progress handling without Celery

### DIFF
--- a/app/optimize.py
+++ b/app/optimize.py
@@ -1,6 +1,6 @@
 import numpy as np
 from sqlalchemy import MetaData, Table, inspect, select
-from flask import session
+from flask import session, has_request_context
 from flask_login import current_user
 
 from . import db
@@ -32,8 +32,14 @@ def _is_number(val: str) -> bool:
     return _parse_numeric(val) is not None
 
 def _get_materials_table():
-    """Връща таблицата materials_grit за текущата схема."""
-    sch = session.get("schema") if current_user.role == "operator" else "main"
+    """Връща таблицата materials_grit за текущата схема.
+
+    If called outside of a request context, defaults to the ``main`` schema.
+    """
+    if has_request_context() and getattr(current_user, "role", None) == "operator":
+        sch = session.get("schema", "main")
+    else:
+        sch = "main"
     meta = MetaData(schema=sch)
     return Table("materials_grit", meta, autoload_with=db.engine)
 
@@ -95,6 +101,7 @@ def optimize_combo(
     mse_threshold: float = MSE_THRESHOLD,
     progress_cb=None,
     constraints=None,
+    cancel_cb=None,
 ):
     """Simple random search optimization.
 
@@ -112,6 +119,9 @@ def optimize_combo(
         Called as ``progress_cb(iteration, best_mse)`` after each step.
     constraints : dict
         Ключ: индекс на материала, стойност: (min, max) ограничения на дяловете.
+    cancel_cb : callable, optional
+        If provided, ``cancel_cb()`` is checked each iteration and stops the
+        search when it returns ``True``.
     """
     n = values.shape[0]
     best_mse = float("inf")
@@ -125,16 +135,19 @@ def optimize_combo(
         return True
 
     for i in range(1, max_iter + 1):
+        if cancel_cb and cancel_cb():
+            break
         w = np.random.dirichlet(np.ones(n))
-        if not _satisfies(w):
-            continue
-        mse = compute_mse(w, values, target)
-        if mse < best_mse:
-            best_mse, best_w = mse, w
+        if _satisfies(w):
+            mse = compute_mse(w, values, target)
+            if mse < best_mse:
+                best_mse, best_w = mse, w
+            if best_mse <= mse_threshold:
+                if progress_cb:
+                    progress_cb(i, best_mse)
+                break
         if progress_cb:
             progress_cb(i, best_mse)
-        if best_mse <= mse_threshold:
-            break
     if best_w is not None:
         return best_mse, best_w
     return None

--- a/app/routes_optimize.py
+++ b/app/routes_optimize.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, render_template, request, jsonify, session
 from flask_login import login_required, current_user
+import time
 from sqlalchemy import MetaData, Table, select
 
 from .optimize import (
@@ -9,7 +10,12 @@ from .optimize import (
     MSE_THRESHOLD,
 )
 
-from .tasks import optimize_task
+from .tasks import (
+    optimize_task,
+    start_local_job,
+    local_job_status,
+    cancel_local_job,
+)
 from kombu.exceptions import OperationalError
 from celery.exceptions import CeleryError
 from redis import Redis
@@ -61,16 +67,27 @@ def start():
         if not _redis_available(redis_url):
             raise RedisConnectionError()
         job = optimize_task.apply_async(args=[params])
-    except (OperationalError, CeleryError, RedisConnectionError, Exception):
-        # Fallback when the Celery broker/backend is unreachable
+        # If no worker picks up the task, fall back to the local implementation
+        time.sleep(0.2)
+        if AsyncResult(job.id, app=optimize_task.app).status == 'PENDING':
+            optimize_task.app.control.revoke(job.id, terminate=True)
+            raise CeleryError('no workers')
+        return jsonify(job_id=job.id), 202
+    except (OperationalError, CeleryError, RedisConnectionError):
+        job_id = start_local_job(params)
+        return jsonify(job_id=job_id), 202
+    except Exception:
         result = optimize_task.run(params)
         return jsonify(status='SUCCESS', result=result), 200
-    return jsonify(job_id=job.id), 202
 
 
 @bp.route('/status/<job_id>', methods=['GET'])
 @login_required
 def status(job_id):
+    local = local_job_status(job_id)
+    if local is not None:
+        return jsonify(local)
+
     job = AsyncResult(job_id, app=optimize_task.app)
     resp = {'status': job.status}
     if job.status == 'PROGRESS':
@@ -83,5 +100,7 @@ def status(job_id):
 @bp.route('/cancel/<job_id>', methods=['POST'])
 @login_required
 def cancel(job_id):
+    if cancel_local_job(job_id):
+        return jsonify({'status': 'CANCELLED'})
     optimize_task.app.control.revoke(job_id, terminate=True)
     return jsonify({'status': 'CANCELLED'})

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1,11 +1,123 @@
 from celery import Celery
-from .optimize import load_data, optimize_combo, MAX_COMBINATIONS, MSE_THRESHOLD
+from .optimize import (
+    load_data,
+    optimize_combo,
+    MAX_COMBINATIONS,
+    MSE_THRESHOLD,
+)
+from threading import Thread, Event
+import uuid
+from flask import current_app
 
 celery = Celery(
     'hypercon',
     broker='redis://localhost:6379/0',
     backend='redis://localhost:6379/1'
 )
+
+# ------------------ Local fallback job handling ------------------
+
+class _LocalJob:
+    def __init__(self, params):
+        self.id = str(uuid.uuid4())
+        self.params = params
+        # Capture the current Flask app so the worker thread can push an
+        # application context when accessing the database.
+        self.app = current_app._get_current_object()
+        self.status = 'PENDING'
+        self.meta = {'current': 0, 'total': params.get('max_combinations', MAX_COMBINATIONS), 'best_mse': None}
+        self.result = None
+        self._cancel = Event()
+        Thread(target=self._run, daemon=True).start()
+
+    def cancel(self):
+        self._cancel.set()
+
+    def _run(self):
+        # ``load_data`` and SQLAlchemy operations require an application context
+        with self.app.app_context():
+            max_comb = self.params.get('max_combinations', MAX_COMBINATIONS)
+            mse_thresh = self.params.get('mse_threshold', MSE_THRESHOLD)
+            try:
+                ids, values, target, prop_cols, constraints = load_data(self.params)
+            except Exception as exc:
+                self.status = 'FAILURE'
+                self.result = {'error': str(exc)}
+                return
+
+        progress = []
+        self.status = 'PROGRESS'
+        self.meta.update(current=0, best_mse=None)
+
+        def cb(step, best):
+            self.meta.update(current=step, best_mse=best)
+            progress.append({'step': step, 'best_mse': best})
+
+        try:
+            out = optimize_combo(
+                values,
+                target,
+                max_comb,
+                mse_thresh,
+                progress_cb=cb,
+                constraints=constraints,
+                cancel_cb=self._cancel.is_set,
+            )
+        except Exception as exc:
+            self.status = 'FAILURE'
+            self.result = {'error': str(exc), 'progress': progress}
+            return
+
+        if self._cancel.is_set():
+            self.status = 'REVOKED'
+            self.result = {'error': 'Cancelled', 'progress': progress}
+            return
+        if not out:
+            self.status = 'FAILURE'
+            self.result = {'error': 'Optimization failed', 'progress': progress}
+            return
+
+        mse, weights = out
+        mixed_profile = (weights @ values).tolist()
+        self.result = {
+            'material_ids': ids,
+            'weights': weights.tolist(),
+            'mse': mse,
+            'prop_columns': prop_cols,
+            'mixed_profile': mixed_profile,
+            'progress': progress,
+        }
+        self.status = 'SUCCESS'
+
+
+_local_jobs = {}
+
+
+def start_local_job(params) -> str:
+    job = _LocalJob(params)
+    _local_jobs[job.id] = job
+    return job.id
+
+
+def local_job_status(job_id):
+    job = _local_jobs.get(job_id)
+    if not job:
+        return None
+    resp = {'status': job.status}
+    if job.status == 'PROGRESS':
+        resp['meta'] = job.meta
+    if job.status in {'SUCCESS', 'FAILURE', 'REVOKED'}:
+        resp['result'] = job.result
+    return resp
+
+
+def cancel_local_job(job_id):
+    job = _local_jobs.get(job_id)
+    if not job:
+        return False
+    job.cancel()
+    return True
+
 
 @celery.task(bind=True)
 def optimize_task(self, params):

--- a/app/templates/optimize.html
+++ b/app/templates/optimize.html
@@ -33,7 +33,7 @@
   </select>
 
   <h3>4. Параметри на оптимизацията</h3>
-  <label>MAX_COMBINATIONS
+  <label>MAX_ITERATIONS
     <input type="number" id="max-comb" value="{{ default_max_comb }}" min="1">
   </label>
   <label>MSE_THRESHOLD
@@ -157,10 +157,18 @@
           if (data.status === 'SUCCESS') {
             clearInterval(pollInterval);
             showResult(data.result);
+          } else if (data.status === 'FAILURE' && data.result) {
+            clearInterval(pollInterval);
+            alert(data.result.error || 'Грешка');
+          } else if (data.status === 'REVOKED') {
+            clearInterval(pollInterval);
+            alert('Процесът е спрян');
           } else if (data.status === 'PROGRESS' && data.meta) {
             const pct = Math.round(100 * data.meta.current / data.meta.total);
             document.getElementById('pct').textContent = pct;
-            document.getElementById('best-mse').textContent = data.meta.best_mse.toFixed(6);
+            const best = data.meta.best_mse;
+            document.getElementById('best-mse').textContent =
+              best != null ? Number(best).toFixed(6) : '-';
           } else {
             document.getElementById('pct').textContent = '...';
           }
@@ -175,7 +183,8 @@
     document.getElementById('pct').textContent = '100';
     if (res.progress && res.progress.length) {
       const last = res.progress[res.progress.length - 1];
-      document.getElementById('best-mse').textContent = last.best_mse.toFixed(6);
+      document.getElementById('best-mse').textContent =
+        last.best_mse != null ? Number(last.best_mse).toFixed(6) : '-';
     }
     const text = `\nMSE: ${res.mse.toFixed(6)}\n` + res.material_ids.map((id,i)=>
       `Material ${id}: ${(res.weights[i]*100).toFixed(2)}%`


### PR DESCRIPTION
## Summary
- detect missing Celery workers and run local optimization instead
- propagate all exceptions from local worker so UI can show failures
- call progress callback each iteration and init local job status earlier
- surface failed jobs in the browser

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: Could not find a matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_688224420ef48328ac72030526ca3c90