### PR TITLE
Handle empty data in optimizer

### DIFF
--- a/app/routes_optimize.py
+++ b/app/routes_optimize.py
@@ -6,7 +6,7 @@ from sqlalchemy import MetaData, Table, select
 from .optimize import (
     _is_number,
     _parse_numeric,
-    MAX_COMBINATIONS,
+    MAX_COMPONENTS,
     MSE_THRESHOLD,
 )
 
@@ -49,12 +49,16 @@ def page_optimize():
     rows = db.session.execute(select(tbl)).mappings().all()
     numeric_cols = [c.key for c in tbl.columns if _is_number(c.key)]
     numeric_cols.sort(key=lambda x: _parse_numeric(x))
+    current_schema = tbl.schema or "public"
+    table_name = tbl.name
     return render_template(
         'optimize.html',
         materials=rows,
         prop_columns=numeric_cols,
-        default_max_comb=MAX_COMBINATIONS,
+        default_max_class=MAX_COMPONENTS,
         default_mse_thr=MSE_THRESHOLD,
+        schema=current_schema,
+        table_name=table_name,
     )
 
 
@@ -62,6 +66,7 @@ def page_optimize():
 @login_required
 def start():
     params = request.json
+    params['schema'] = session.get('schema') if current_user.role == 'operator' else 'main'
     redis_url = optimize_task.app.conf.broker_url
     try:
         if not _redis_available(redis_url):

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -2,7 +2,8 @@ from celery import Celery
 from .optimize import (
     load_data,
     optimize_combo,
-    MAX_COMBINATIONS,
+    MAX_ITERATIONS,
+    MAX_COMPONENTS,
     MSE_THRESHOLD,
 )
 from threading import Thread, Event
@@ -25,7 +26,11 @@ class _LocalJob:
         # application context when accessing the database.
         self.app = current_app._get_current_object()
         self.status = 'PENDING'
-        self.meta = {'current': 0, 'total': params.get('max_combinations', MAX_COMBINATIONS), 'best_mse': None}
+        self.meta = {
+            'current': 0,
+            'total': params.get('iterations', MAX_ITERATIONS),
+            'best_mse': None,
+        }
         self.result = None
         self._cancel = Event()
         Thread(target=self._run, daemon=True).start()
@@ -36,7 +41,8 @@ class _LocalJob:
     def _run(self):
         # ``load_data`` and SQLAlchemy operations require an application context
         with self.app.app_context():
-            max_comb = self.params.get('max_combinations', MAX_COMBINATIONS)
+            max_iter = self.params.get('iterations', MAX_ITERATIONS)
+            max_comp = self.params.get('max_components', MAX_COMPONENTS)
             mse_thresh = self.params.get('mse_threshold', MSE_THRESHOLD)
             try:
                 ids, values, target, prop_cols, constraints = load_data(self.params)
@@ -57,8 +63,9 @@ class _LocalJob:
             out = optimize_combo(
                 values,
                 target,
-                max_comb,
-                mse_thresh,
+                max_iter=max_iter,
+                mse_threshold=mse_thresh,
+                max_components=max_comp,
                 progress_cb=cb,
                 constraints=constraints,
                 cancel_cb=self._cancel.is_set,
@@ -126,7 +133,8 @@ def optimize_task(self, params):
     params идва от фронтенда и съдържа selected_ids, constraints,
     prop_min и prop_max.
     """
-    max_comb = params.get('max_combinations', MAX_COMBINATIONS)
+    max_iter = params.get('iterations', MAX_ITERATIONS)
+    max_comp = params.get('max_components', MAX_COMPONENTS)
     mse_thresh = params.get('mse_threshold', MSE_THRESHOLD)
 
     try:
@@ -140,10 +148,18 @@ def optimize_task(self, params):
 
     def cb(step, best):
         if update_enabled:
-            self.update_state(state='PROGRESS', meta={'current': step, 'total': max_comb, 'best_mse': best})
+            self.update_state(state='PROGRESS', meta={'current': step, 'total': max_iter, 'best_mse': best})
         progress.append({'step': step, 'best_mse': best})
 
-    out = optimize_combo(values, target, max_comb, mse_thresh, progress_cb=cb, constraints=constraints)
+    out = optimize_combo(
+        values,
+        target,
+        max_iter=max_iter,
+        mse_threshold=mse_thresh,
+        max_components=max_comp,
+        progress_cb=cb,
+        constraints=constraints,
+    )
     if not out:
         return {'error': 'Optimization failed', 'progress': progress}
     mse, weights = out

--- a/app/templates/optimize.html
+++ b/app/templates/optimize.html
@@ -2,6 +2,10 @@
 {% block title %}Оптимизация{% endblock %}
 {% block content %}
 <h1>Оптимизация на рецепта</h1>
+<div class="mb-3">
+  <strong>Схема:</strong> {{ schema }}<br>
+  <strong>Таблица:</strong> {{ table_name }}
+</div>
 
 <form id="opt-form">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -33,8 +37,8 @@
   </select>
 
   <h3>4. Параметри на оптимизацията</h3>
-  <label>MAX_ITERATIONS
-    <input type="number" id="max-comb" value="{{ default_max_comb }}" min="1">
+  <label>MAX_COMPONENTS
+    <input type="number" id="max-class" value="{{ default_max_class }}" min="1">
   </label>
   <label>MSE_THRESHOLD
     <input type="number" id="mse-threshold" step="0.0001" value="{{ default_mse_thr }}">
@@ -113,7 +117,7 @@
       constraints,
       prop_min: parseFloat(document.getElementById('prop-min').value),
       prop_max: parseFloat(document.getElementById('prop-max').value),
-      max_combinations: parseInt(document.getElementById('max-comb').value),
+      max_components: parseInt(document.getElementById('max-class').value),
       mse_threshold: parseFloat(document.getElementById('mse-threshold').value)
     };
     fetch('/optimize/start', {


### PR DESCRIPTION
## Summary
- catch empty rows/columns when loading optimization data
- show schema info on optimize page
- persist schema during optimization
- add configurable max component limit for optimizations

## Testing
- `python -m py_compile app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688230bfd6bc8328b476774000205ef9