### PR TITLE
Add SciPy-based continuous optimization method

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -111,8 +111,15 @@ def create_app():
     # ── Глобален error handler за логване на неконтролирани изключения ───────
     @app.errorhandler(Exception)
     def handle_exception(e):
+        """Log unexpected server errors and propagate standard HTTP errors."""
+        from werkzeug.exceptions import HTTPException
+
+        if isinstance(e, HTTPException) and e.code < 500:
+            # Don't log common 4xx errors as application errors
+            return e
+
         app.logger.error("Unhandled Exception", exc_info=e)
-        raise
+        return e
 
     # ── Създаване на таблиците при стартиране (MVP shortcut) ─────────────────
     with app.app_context():

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -2,6 +2,7 @@ from celery import Celery
 from .optimize import (
     load_data,
     optimize_combo,
+    optimize_continuous,
     MAX_COMPONENTS,
     MSE_THRESHOLD,
     WEIGHT_STEP,
@@ -67,15 +68,23 @@ class _LocalJob:
             progress.append({'step': step, 'best_mse': best})
 
         try:
-            out = optimize_combo(
-                values,
-                target,
-                mse_threshold=mse_thresh,
-                max_components=max_comp,
-                progress_cb=cb,
-                constraints=constraints,
-                cancel_cb=self._cancel.is_set,
-            )
+            method = self.params.get('method', 'combo')
+            if method == 'continuous':
+                out = optimize_continuous(
+                    values,
+                    target,
+                    constraints=constraints,
+                )
+            else:
+                out = optimize_combo(
+                    values,
+                    target,
+                    mse_threshold=mse_thresh,
+                    max_components=max_comp,
+                    progress_cb=cb,
+                    constraints=constraints,
+                    cancel_cb=self._cancel.is_set,
+                )
         except Exception as exc:
             self.status = 'FAILURE'
             self.result = {'error': str(exc), 'progress': progress}
@@ -162,14 +171,22 @@ def optimize_task(self, params):
             self.update_state(state='PROGRESS', meta={'current': step, 'total': total, 'best_mse': best})
         progress.append({'step': step, 'best_mse': best})
 
-    out = optimize_combo(
-        values,
-        target,
-        mse_threshold=mse_thresh,
-        max_components=max_comp,
-        progress_cb=cb,
-        constraints=constraints,
-    )
+    method = params.get('method', 'combo')
+    if method == 'continuous':
+        out = optimize_continuous(
+            values,
+            target,
+            constraints=constraints,
+        )
+    else:
+        out = optimize_combo(
+            values,
+            target,
+            mse_threshold=mse_thresh,
+            max_components=max_comp,
+            progress_cb=cb,
+            constraints=constraints,
+        )
     if not out:
         return {'error': 'Optimization failed', 'progress': progress}
     mse, weights = out

--- a/app/templates/optimize.html
+++ b/app/templates/optimize.html
@@ -43,6 +43,12 @@
   <label>MSE_THRESHOLD
     <input type="number" id="mse-threshold" step="0.0001" value="{{ default_mse_thr }}">
   </label>
+  <label>Метод
+    <select id="method">
+      <option value="combo">Комбинаторен</option>
+      <option value="continuous">Нелинеен</option>
+    </select>
+  </label>
 
   <button type="submit">Стартирай</button>
 </form>
@@ -118,7 +124,8 @@
       prop_min: parseFloat(document.getElementById('prop-min').value),
       prop_max: parseFloat(document.getElementById('prop-max').value),
       max_components: parseInt(document.getElementById('max-class').value),
-      mse_threshold: parseFloat(document.getElementById('mse-threshold').value)
+      mse_threshold: parseFloat(document.getElementById('mse-threshold').value),
+      method: document.getElementById('method').value
     };
     fetch('/optimize/start', {
       method: 'POST',

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ waitress==2.1.2
 numpy==1.26.4
 celery==5.3.6
 redis==4.6.0
+scipy==1.11.4


### PR DESCRIPTION
## Summary
- integrate SciPy to support continuous optimization of material fractions
- expose new `optimize_continuous` function in `app/optimize.py`
- allow selection between combo and continuous methods
- update Celery tasks and local job runner with new logic
- add method dropdown in optimization page
- include SciPy in requirements
- avoid logging 404/4xx errors as server crashes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68889ad25e788328a4e1bacfbdc0fe65