### PR TITLE
Fix circular import in app init

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,8 +14,9 @@ from flask_bcrypt import Bcrypt
 from flask_wtf import CSRFProtect
 from sqlalchemy import text
 from .config import DB_URI
-from .routes_optimize import bp as optimize_bp
-from . import tasks
+# Import blueprints and task modules lazily inside ``create_app`` to avoid
+# circular import issues during initialization.
+# from . import tasks  # Imported in ``create_app`` when needed.
 
 # ── Extensions ────────────────────────────────────────────────────────────────
 db            = SQLAlchemy()
@@ -129,6 +130,8 @@ def create_app():
     from .routes_auth      import bp as auth_bp
     from .routes_admin     import bp as admin_bp
     from .routes_materials import bp as materials_bp
+    from .routes_optimize  import bp as optimize_bp
+    from . import tasks  # ensure tasks are registered
 
     app.register_blueprint(auth_bp,      url_prefix="/auth")
     app.register_blueprint(admin_bp,     url_prefix="/admin")


### PR DESCRIPTION
## Summary
- avoid circular import by moving blueprint and task imports into `create_app`

## Testing
- `python run.py` *(fails: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_6888b3ab2e808328b3eefec8c1780b9f