### PR TITLE
Normalize material profiles across dataset

### DIFF
--- a/app/optimize.py
+++ b/app/optimize.py
@@ -153,14 +153,15 @@ def run_full_optimization(schema: Optional[str] = None):
 
     ids, values, _target, prop_cols = load_data(schema)
 
+    profiles = values
     etalon = etalon_from_columns(prop_cols)
 
-    best = find_best_mix(values, etalon)
+    best = find_best_mix(profiles, etalon)
     if not best:
         return None
 
     mse, combo, weights = best
-    mixed = np.dot(weights, values[list(combo)])
+    mixed = np.dot(weights, profiles[list(combo)])
     return {
         'material_ids': [ids[i] for i in combo],
         'weights':      weights.tolist(),


### PR DESCRIPTION
## Summary
- remove redundant compute_profiles helper
- use material rows directly when optimizing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a1f4286c88328ad926f2e0c2bb4e1