### PR TITLE
Fix optimize result serialization

### DIFF
--- a/app/optimize.py
+++ b/app/optimize.py
@@ -304,7 +304,8 @@ def run_full_optimization(
     mixed = weights.dot(values)
 
     return {
-        'material_ids': [ids[i] for i in combo],
+        # Convert NumPy integer IDs to plain Python ints for JSON serialization
+        'material_ids': [int(ids[i]) for i in combo],
         'weights':      weights.tolist(),
         'best_mse':     mse,
         'prop_columns': prop_cols,

--- a/app/templates/optimize.html
+++ b/app/templates/optimize.html
@@ -20,10 +20,11 @@
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
+const runUrl = "{{ url_for('optimize_bp.run') }}";
 document.getElementById('opt-form').addEventListener('submit', e=>{
   e.preventDefault();
   const formData = new FormData(e.target);
-  fetch('/optimize/run', {
+  fetch(runUrl, {
     method: 'POST',
     body: formData
   })


### PR DESCRIPTION
## Summary
- fix optimization response by converting NumPy IDs to regular Python ints
- use `url_for` for the optimize run endpoint in the template

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688b5a9340148328ae0a14ceac6503cb