### PR TITLE
Display optimization result table and chart

### DIFF
--- a/app/optimize.py
+++ b/app/optimize.py
@@ -304,7 +304,8 @@ def run_full_optimization(
     mixed = weights.dot(values)
 
     return {
-        'material_ids': [ids[i] for i in combo],
+        # Convert NumPy integer IDs to plain Python ints for JSON serialization
+        'material_ids': [int(ids[i]) for i in combo],
         'weights':      weights.tolist(),
         'best_mse':     mse,
         'prop_columns': prop_cols,

--- a/app/templates/optimize.html
+++ b/app/templates/optimize.html
@@ -7,38 +7,50 @@
   <strong>Таблица:</strong> {{ table_name }}
 </div>
 
-<form id="opt-form">
+<form id="opt-form" action="{{ url_for('optimize_bp.run') }}" method="post">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-  <button id="run" class="btn btn-primary">Стартирай</button>
+  <button id="run" type="button" class="btn btn-primary">Стартирай</button>
 </form>
 
 <div id="result" style="display:none;">
   <h3>Резултат</h3>
-  <pre id="text-result"></pre>
+  <p id="best-mse"></p>
+  <table class="table table-sm" id="weights-table">
+    <thead>
+      <tr><th>Материал ID</th><th>Тегло %</th></tr>
+    </thead>
+    <tbody id="weights-body"></tbody>
+  </table>
   <canvas id="chart" width="600" height="300"></canvas>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
-document.getElementById('opt-form').addEventListener('submit', e=>{
+const form = document.getElementById('opt-form');
+const runBtn = document.getElementById('run');
+runBtn.addEventListener('click', e => {
   e.preventDefault();
-  const formData = new FormData(e.target);
-  fetch('/optimize/run', {
+  const formData = new FormData(form);
+  fetch(form.action, {
     method: 'POST',
     body: formData
   })
-    .then(r=>r.json())
+    .then(r => r.json())
     .then(showResult);
 });
 
 function showResult(res){
   document.getElementById('result').style.display='block';
-  // текстов резултат
-  let txt = `Best MSE: ${res.best_mse}\n`;
+
+  // числова информация
+  document.getElementById('best-mse').textContent = `Best MSE: ${res.best_mse}`;
+  const tbody = document.getElementById('weights-body');
+  tbody.innerHTML = '';
   res.material_ids.forEach((id,i)=>{
-    txt += `Material ${id}: ${(res.weights[i]*100).toFixed(2)}%\n`;
+    const row = document.createElement('tr');
+    row.innerHTML = `<td>${id}</td><td>${(res.weights[i]*100).toFixed(2)}%</td>`;
+    tbody.appendChild(row);
   });
-  document.getElementById('text-result').textContent = txt;
 
   // графика
   new Chart(document.getElementById('chart'),{


### PR DESCRIPTION
## Summary
- show best MSE and weights in a table
- plot target and mixed profiles using Chart.js
- prevent form submission reload by using a button click handler

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688b5a9340148328ae0a14ceac6503cb