### PR TITLE
Add selectable materials and ratio constraints

### DIFF
--- a/app/optimize.py
+++ b/app/optimize.py
@@ -88,14 +88,20 @@ def load_data(schema: Optional[str] = None):
     return ids, values, target, numeric_cols
 
 
-def load_recipe_data(property_limit: float, schema: Optional[str] = None):
-    """Load materials and numeric columns with optional limit."""
+def load_recipe_data(
+    property_limit: float,
+    schema: Optional[str] = None,
+    allowed_ids: Optional[list[int]] = None,
+):
+    """Load materials and numeric columns with optional limit and filtering."""
 
     tbl = _get_materials_table(schema)
 
     stmt = select(tbl)
     if 'user_id' in tbl.c:
         stmt = stmt.where(tbl.c.user_id == current_user.id)
+    if allowed_ids:
+        stmt = stmt.where(tbl.c.id.in_(allowed_ids))
 
     df = pd.read_sql(stmt, db.engine)
     df = df.replace(r'^\s*$', np.nan, regex=True)
@@ -126,11 +132,28 @@ def optimize_combo(
     values: np.ndarray,
     target: np.ndarray,
     n_restarts: int = 20,
+    constraints: list[tuple[int, str, float]] | None = None,
 ) -> tuple[float, tuple[int, ...], np.ndarray] | None:
     """Optimize weights for a specific combination using multi-start SLSQP."""
 
     subset = values[list(combo)]
-    out = optimize_with_restarts(subset, target, n_restarts)
+
+    # Convert global constraint indices to local positions
+    local_cons = []
+    if constraints:
+        pos_map = {g_idx: i for i, g_idx in enumerate(combo)}
+        for idx, op, val in constraints:
+            if idx not in pos_map:
+                continue
+            loc = pos_map[idx]
+            if op == '>':
+                local_cons.append({'type': 'ineq', 'fun': lambda w, l=loc, v=val: w[l] - v})
+            elif op == '<':
+                local_cons.append({'type': 'ineq', 'fun': lambda w, l=loc, v=val: v - w[l]})
+            elif op == '=':
+                local_cons.append({'type': 'eq', 'fun': lambda w, l=loc, v=val: w[l] - v})
+
+    out = optimize_with_restarts(subset, target, n_restarts, local_cons)
     if not out:
         return None
     mse, weights = out
@@ -177,17 +200,12 @@ def compute_mse(weights: np.ndarray,
     return float(np.mean((mix - target)**2))
 
 # Continuous optimization with restarts to avoid local minima
-def optimize_with_restarts(values: np.ndarray,
-                           target: np.ndarray,
-                           n_restarts: int = RESTARTS):
-    k = values.shape[0]
-    bounds = [(0.0, 1.0)] * k
-    cons = ({'type': 'eq', 'fun': lambda w: w.sum() - 1.0},)
-    best = None
-
-def optimize_with_restarts(values: np.ndarray,
-                           target: np.ndarray,
-                           n_restarts: int = 20):
+def optimize_with_restarts(
+    values: np.ndarray,
+    target: np.ndarray,
+    n_restarts: int = 20,
+    extra_cons: list[dict] | None = None,
+):
     """Run SLSQP from multiple starting points and return the best result."""
 
     if minimize is None:
@@ -199,37 +217,23 @@ def optimize_with_restarts(values: np.ndarray,
         return compute_mse(w, values, target)
 
     bounds = [(0.0, 1.0)] * k
-    cons = ({'type': 'eq', 'fun': lambda w: w.sum() - 1.0},)
-
-    inits = [np.full(k, 1.0 / k)]
-    inits += list(np.random.dirichlet(np.ones(k), size=n_restarts))
-
-def optimize_with_restarts(values: np.ndarray,
-                           target: np.ndarray,
-                           n_restarts: int = 20):
-    """Run SLSQP from multiple starting points and return the best result."""
-
-    if minimize is None:
-        raise RuntimeError("SciPy is required for continuous optimization")
-
-    k = values.shape[0]
-
-    def obj(w: np.ndarray) -> float:
-        return compute_mse(w, values, target)
-
-    bounds = [(0.0, 1.0)] * k
-    cons = ({'type': 'eq', 'fun': lambda w: w.sum() - 1.0},)
+    cons = [{'type': 'eq', 'fun': lambda w: w.sum() - 1.0}]
+    if extra_cons:
+        cons.extend(extra_cons)
 
     inits = [np.full(k, 1.0 / k)]
     inits += list(np.random.dirichlet(np.ones(k), size=n_restarts))
 
     best = None
     for x0 in inits:
-        res = minimize(obj, x0,
-                       method='SLSQP',
-                       bounds=bounds,
-                       constraints=cons,
-                       options={'ftol': 1e-9, 'eps': 1e-4, 'maxiter': 50000})
+        res = minimize(
+            obj,
+            x0,
+            method='SLSQP',
+            bounds=bounds,
+            constraints=cons,
+            options={'ftol': 1e-9, 'eps': 1e-4, 'maxiter': 50000},
+        )
         if not res.success:
             continue
         cand = (res.fun, res.x)
@@ -246,6 +250,7 @@ def find_best_mix(names: np.ndarray,
                   max_combo_num: int,
                   mse_threshold: float | None = None,
                   n_restarts: int = RESTARTS,
+                  constraints: list[tuple[int, str, float]] | None = None,
                   ):
     """Evaluate all material combinations and return the best result."""
 
@@ -261,7 +266,17 @@ def find_best_mix(names: np.ndarray,
         pct = i / total * 100
         sys.stdout.write(f"\rProgress: {pct:6.2f}% ({i}/{total})")
         sys.stdout.flush()
-        res = optimize_combo(combo, values, target, n_restarts)
+        # Skip combos that don't contain materials from equality/">" constraints
+        if constraints:
+            required = {
+                idx
+                for idx, op, _ in constraints
+                if op in ('=', '>')
+            }
+            if not required.issubset(set(combo)):
+                continue
+
+        res = optimize_combo(combo, values, target, n_restarts, constraints)
         if res:
             results.append(res)
             mse_val, combo_idx, frac_vals = res
@@ -288,13 +303,33 @@ def run_full_optimization(
     property_limit: float = 1000.0,
     max_combo_num: int = MAX_COMPONENTS,
     mse_threshold: float | None = 0.0004,
+    material_ids: Optional[list[int]] = None,
+    constraints: Optional[list[tuple[int, str, float]]] = None,
 ):
     """Load materials and search for the optimal mix."""
 
-    ids, names, values, target, prop_cols = load_recipe_data(property_limit, schema)
+    ids, names, values, target, prop_cols = load_recipe_data(
+        property_limit, schema, material_ids
+    )
 
-    best = find_best_mix(names, values, target, prop_cols,
-                         max_combo_num, mse_threshold, RESTARTS)
+    # Map DB id -> index in arrays
+    id_to_idx = {mid: i for i, mid in enumerate(ids)}
+    constr_idx: list[tuple[int, str, float]] = []
+    if constraints:
+        for mid, op, val in constraints:
+            if mid in id_to_idx:
+                constr_idx.append((id_to_idx[mid], op, float(val)))
+
+    best = find_best_mix(
+        names,
+        values,
+        target,
+        prop_cols,
+        max_combo_num,
+        mse_threshold,
+        RESTARTS,
+        constr_idx,
+    )
 
     if not best:
         return None

--- a/app/routes_optimize.py
+++ b/app/routes_optimize.py
@@ -1,6 +1,7 @@
-from flask import Blueprint, render_template, jsonify
+from flask import Blueprint, render_template, jsonify, request
 from flask_login import login_required
 
+from . import db
 from .optimize import run_full_optimization, _get_materials_table
 
 bp = Blueprint('optimize_bp', __name__)
@@ -11,15 +12,35 @@ def page():
     tbl = _get_materials_table()
     schema = tbl.schema or 'public'
     table_name = tbl.name
-    return render_template('optimize.html',
-                           schema=schema,
-                           table_name=table_name)
+    rows = db.session.execute(tbl.select()).mappings().all()
+    cols = list(tbl.columns.keys())
+    nonnum = [c for c in cols if not c.isdigit()]
+    num = sorted([c for c in cols if c.isdigit()], key=lambda x: int(x))
+    columns = ['use'] + nonnum + num
+    return render_template(
+        'optimize.html',
+        schema=schema,
+        table_name=table_name,
+        columns=columns,
+        rows=rows,
+    )
 
 @bp.route('/run', methods=['POST'])
 @login_required
 def run():
+    import json
+
+    materials_raw = request.form.get('materials')
+    constraints_raw = request.form.get('constraints')
+
+    material_ids = json.loads(materials_raw) if materials_raw else None
+    constr = json.loads(constraints_raw) if constraints_raw else None
+
     try:
-        result = run_full_optimization()
+        result = run_full_optimization(
+            material_ids=material_ids,
+            constraints=[(int(c['id']), c['op'], float(c['val'])) for c in constr] if constr else None,
+        )
     except Exception as exc:
         return jsonify(error=str(exc)), 400
     if result is None:

--- a/app/static/optimize.js
+++ b/app/static/optimize.js
@@ -2,10 +2,58 @@ const form = document.getElementById('opt-form');
 const runBtn = document.getElementById('run');
 const spinner = document.getElementById('spinner');
 const resultDiv = document.getElementById('result');
+const materials = JSON.parse(document.getElementById('materials-data').textContent);
+const addConstrBtn = document.getElementById('add-constr');
+const constrBody = document.getElementById('constraints-body');
+
+addConstrBtn.addEventListener('click', () => {
+  const tr = document.createElement('tr');
+  const td1 = document.createElement('td');
+  const sel = document.createElement('select');
+  sel.className = 'con-mat';
+  materials.forEach(m => {
+    const o = document.createElement('option');
+    o.value = m.id;
+    o.textContent = m.name;
+    sel.appendChild(o);
+  });
+  td1.appendChild(sel);
+  const td2 = document.createElement('td');
+  const op = document.createElement('select');
+  op.className = 'con-op';
+  ['>','<','='].forEach(s => {
+    const opt = document.createElement('option');
+    opt.value = s;
+    opt.textContent = s;
+    op.appendChild(opt);
+  });
+  td2.appendChild(op);
+  const td3 = document.createElement('td');
+  const val = document.createElement('input');
+  val.type = 'number';
+  val.min = '0';
+  val.max = '1';
+  val.step = 'any';
+  val.className = 'con-val';
+  td3.appendChild(val);
+  tr.appendChild(td1);
+  tr.appendChild(td2);
+  tr.appendChild(td3);
+  constrBody.appendChild(tr);
+});
 
 runBtn.addEventListener('click', e => {
   e.preventDefault();
-  const formData = new FormData(form);
+  const formData = new FormData();
+  formData.append('csrf_token', form.querySelector('input[name="csrf_token"]').value);
+  const ids = Array.from(document.querySelectorAll('.use-chk:checked')).map(c => parseInt(c.value));
+  const constr = Array.from(constrBody.querySelectorAll('tr')).map(tr => ({
+    id: parseInt(tr.querySelector('.con-mat').value),
+    op: tr.querySelector('.con-op').value,
+    val: parseFloat(tr.querySelector('.con-val').value || 0)
+  }));
+  formData.append('materials', JSON.stringify(ids));
+  formData.append('constraints', JSON.stringify(constr));
   runBtn.disabled = true;
   resultDiv.classList.add('d-none');
   spinner.classList.remove('d-none');

--- a/app/templates/optimize.html
+++ b/app/templates/optimize.html
@@ -9,6 +9,36 @@
 
 <form id="opt-form" action="{{ url_for('optimize_bp.run') }}" method="post">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+  <table class="table table-striped" id="materials-table">
+    <thead>
+      <tr>
+        {% for col in columns %}
+          <th>{{ col == 'use' and 'Избор' or col }}</th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in rows %}
+        <tr>
+          <td><input type="checkbox" class="use-chk" value="{{ row['id'] }}" checked></td>
+          {% for col in columns[1:] %}
+            <td>{{ row[col] }}</td>
+          {% endfor %}
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <div class="mb-3">
+    <h5>Ограничения</h5>
+    <table class="table table-sm" id="constraints-table">
+      <thead><tr><th>Материал</th><th>Знак</th><th>Стойност</th></tr></thead>
+      <tbody id="constraints-body"></tbody>
+    </table>
+    <button type="button" id="add-constr" class="btn btn-secondary">Добави ограничение</button>
+  </div>
+
   <button id="run" type="button" class="btn btn-primary">Стартирай</button>
   <div id="spinner" class="d-none mt-2">
     <div class="spinner-border" role="status">
@@ -29,6 +59,11 @@
   <canvas id="chart" width="600" height="300"></canvas>
 </div>
 
+<script id="materials-data" type="application/json">
+  [
+  {% for r in rows %}{"id": {{ r['id'] }}, "name": "{{ r['material_name'] }}"}{% if not loop.last %},{% endif %}{% endfor %}
+  ]
+</script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="{{ url_for('static', filename='optimize.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- extend optimizer UI to list materials with checkboxes and constraint editor
- send selected materials and constraints from frontend
- update optimize routes and backend functions to handle selected materials and constraints

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b7aef22f48328a6d4a6f8db33672a