### PR TITLE
Run optimization asynchronously

### DIFF
--- a/app/optimize.py
+++ b/app/optimize.py
@@ -26,6 +26,13 @@ POWER = 0.217643428858232
 MAX_COMPONENTS = 7  # maximum number of materials considered in a mix
 RESTARTS = 10       # number of random restarts for SLSQP
 
+# progress tracking shared by optimization routines
+_PROGRESS = {"total": 0, "done": 0}
+
+def get_progress() -> dict:
+    """Return current optimization progress."""
+    return dict(_PROGRESS)
+
 
 # Utility to parse numeric column names
 import re
@@ -88,14 +95,20 @@ def load_data(schema: Optional[str] = None):
     return ids, values, target, numeric_cols
 
 
-def load_recipe_data(property_limit: float, schema: Optional[str] = None):
-    """Load materials and numeric columns with optional limit."""
+def load_recipe_data(
+    property_limit: float,
+    schema: Optional[str] = None,
+    allowed_ids: Optional[list[int]] = None,
+):
+    """Load materials and numeric columns with optional limit and filtering."""
 
     tbl = _get_materials_table(schema)
 
     stmt = select(tbl)
     if 'user_id' in tbl.c:
         stmt = stmt.where(tbl.c.user_id == current_user.id)
+    if allowed_ids:
+        stmt = stmt.where(tbl.c.id.in_(allowed_ids))
 
     df = pd.read_sql(stmt, db.engine)
     df = df.replace(r'^\s*$', np.nan, regex=True)
@@ -126,11 +139,28 @@ def optimize_combo(
     values: np.ndarray,
     target: np.ndarray,
     n_restarts: int = 20,
+    constraints: list[tuple[int, str, float]] | None = None,
 ) -> tuple[float, tuple[int, ...], np.ndarray] | None:
     """Optimize weights for a specific combination using multi-start SLSQP."""
 
     subset = values[list(combo)]
-    out = optimize_with_restarts(subset, target, n_restarts)
+
+    # Convert global constraint indices to local positions
+    local_cons = []
+    if constraints:
+        pos_map = {g_idx: i for i, g_idx in enumerate(combo)}
+        for idx, op, val in constraints:
+            if idx not in pos_map:
+                continue
+            loc = pos_map[idx]
+            if op == '>':
+                local_cons.append({'type': 'ineq', 'fun': lambda w, l=loc, v=val: w[l] - v})
+            elif op == '<':
+                local_cons.append({'type': 'ineq', 'fun': lambda w, l=loc, v=val: v - w[l]})
+            elif op == '=':
+                local_cons.append({'type': 'eq', 'fun': lambda w, l=loc, v=val: w[l] - v})
+
+    out = optimize_with_restarts(subset, target, n_restarts, local_cons)
     if not out:
         return None
     mse, weights = out
@@ -177,17 +207,12 @@ def compute_mse(weights: np.ndarray,
     return float(np.mean((mix - target)**2))
 
 # Continuous optimization with restarts to avoid local minima
-def optimize_with_restarts(values: np.ndarray,
-                           target: np.ndarray,
-                           n_restarts: int = RESTARTS):
-    k = values.shape[0]
-    bounds = [(0.0, 1.0)] * k
-    cons = ({'type': 'eq', 'fun': lambda w: w.sum() - 1.0},)
-    best = None
-
-def optimize_with_restarts(values: np.ndarray,
-                           target: np.ndarray,
-                           n_restarts: int = 20):
+def optimize_with_restarts(
+    values: np.ndarray,
+    target: np.ndarray,
+    n_restarts: int = 20,
+    extra_cons: list[dict] | None = None,
+):
     """Run SLSQP from multiple starting points and return the best result."""
 
     if minimize is None:
@@ -199,37 +224,23 @@ def optimize_with_restarts(values: np.ndarray,
         return compute_mse(w, values, target)
 
     bounds = [(0.0, 1.0)] * k
-    cons = ({'type': 'eq', 'fun': lambda w: w.sum() - 1.0},)
-
-    inits = [np.full(k, 1.0 / k)]
-    inits += list(np.random.dirichlet(np.ones(k), size=n_restarts))
-
-def optimize_with_restarts(values: np.ndarray,
-                           target: np.ndarray,
-                           n_restarts: int = 20):
-    """Run SLSQP from multiple starting points and return the best result."""
-
-    if minimize is None:
-        raise RuntimeError("SciPy is required for continuous optimization")
-
-    k = values.shape[0]
-
-    def obj(w: np.ndarray) -> float:
-        return compute_mse(w, values, target)
-
-    bounds = [(0.0, 1.0)] * k
-    cons = ({'type': 'eq', 'fun': lambda w: w.sum() - 1.0},)
+    cons = [{'type': 'eq', 'fun': lambda w: w.sum() - 1.0}]
+    if extra_cons:
+        cons.extend(extra_cons)
 
     inits = [np.full(k, 1.0 / k)]
     inits += list(np.random.dirichlet(np.ones(k), size=n_restarts))
 
     best = None
     for x0 in inits:
-        res = minimize(obj, x0,
-                       method='SLSQP',
-                       bounds=bounds,
-                       constraints=cons,
-                       options={'ftol': 1e-9, 'eps': 1e-4, 'maxiter': 50000})
+        res = minimize(
+            obj,
+            x0,
+            method='SLSQP',
+            bounds=bounds,
+            constraints=cons,
+            options={'ftol': 1e-9, 'eps': 1e-4, 'maxiter': 50000},
+        )
         if not res.success:
             continue
         cand = (res.fun, res.x)
@@ -246,6 +257,8 @@ def find_best_mix(names: np.ndarray,
                   max_combo_num: int,
                   mse_threshold: float | None = None,
                   n_restarts: int = RESTARTS,
+                  constraints: list[tuple[int, str, float]] | None = None,
+                  progress_cb=None,
                   ):
     """Evaluate all material combinations and return the best result."""
 
@@ -254,6 +267,8 @@ def find_best_mix(names: np.ndarray,
     for r in range(1, min(max_combo_num, n) + 1):
         combos.extend(itertools.combinations(range(n), r))
     total = len(combos)
+    if progress_cb:
+        progress_cb(0, total)
 
     best = None
     results: list[tuple[float, tuple[int, ...], np.ndarray]] = []
@@ -261,7 +276,19 @@ def find_best_mix(names: np.ndarray,
         pct = i / total * 100
         sys.stdout.write(f"\rProgress: {pct:6.2f}% ({i}/{total})")
         sys.stdout.flush()
-        res = optimize_combo(combo, values, target, n_restarts)
+        if progress_cb:
+            progress_cb(i, total)
+        # Skip combos that don't contain materials from equality/">" constraints
+        if constraints:
+            required = {
+                idx
+                for idx, op, _ in constraints
+                if op in ('=', '>')
+            }
+            if not required.issubset(set(combo)):
+                continue
+
+        res = optimize_combo(combo, values, target, n_restarts, constraints)
         if res:
             results.append(res)
             mse_val, combo_idx, frac_vals = res
@@ -288,13 +315,48 @@ def run_full_optimization(
     property_limit: float = 1000.0,
     max_combo_num: int = MAX_COMPONENTS,
     mse_threshold: float | None = 0.0004,
+    material_ids: Optional[list[int]] = None,
+    constraints: Optional[list[tuple[int, str, float]]] = None,
+    progress: Optional[dict] = None,
 ):
     """Load materials and search for the optimal mix."""
 
-    ids, names, values, target, prop_cols = load_recipe_data(property_limit, schema)
+    # choose progress dict
+    prog = progress if progress is not None else _PROGRESS
 
-    best = find_best_mix(names, values, target, prop_cols,
-                         max_combo_num, mse_threshold, RESTARTS)
+    # reset progress
+    prog["total"] = 0
+    prog["done"] = 0
+
+    ids, names, values, target, prop_cols = load_recipe_data(
+        property_limit, schema, material_ids
+    )
+
+    # Map DB id -> index in arrays
+    id_to_idx = {mid: i for i, mid in enumerate(ids)}
+    constr_idx: list[tuple[int, str, float]] = []
+    if constraints:
+        for mid, op, val in constraints:
+            if mid in id_to_idx:
+                constr_idx.append((id_to_idx[mid], op, float(val)))
+
+    def progress_cb(done: int, total: int):
+        prog["total"] = int(total)
+        prog["done"] = int(done)
+
+    best = find_best_mix(
+        names,
+        values,
+        target,
+        prop_cols,
+        max_combo_num,
+        mse_threshold,
+        RESTARTS,
+        constr_idx,
+        progress_cb,
+    )
+
+    prog["done"] = prog.get("total", 0)
 
     if not best:
         return None

--- a/app/routes_optimize.py
+++ b/app/routes_optimize.py
@@ -1,9 +1,15 @@
-from flask import Blueprint, render_template, jsonify
+from flask import Blueprint, render_template, jsonify, request
 from flask_login import login_required
+from threading import Thread
+from uuid import uuid4
 
+from . import db
 from .optimize import run_full_optimization, _get_materials_table
 
 bp = Blueprint('optimize_bp', __name__)
+
+# simple in-memory job store
+_jobs: dict[str, dict] = {}
 
 @bp.route('', methods=['GET'])
 @login_required
@@ -11,17 +17,63 @@ def page():
     tbl = _get_materials_table()
     schema = tbl.schema or 'public'
     table_name = tbl.name
-    return render_template('optimize.html',
-                           schema=schema,
-                           table_name=table_name)
+    rows = db.session.execute(tbl.select()).mappings().all()
+    cols = list(tbl.columns.keys())
+    nonnum = [c for c in cols if not c.isdigit()]
+    num = sorted([c for c in cols if c.isdigit()], key=lambda x: int(x))
+    columns = ['use'] + nonnum + num
+    materials = [{'id': r['id'], 'name': r['material_name']} for r in rows]
+    return render_template(
+        'optimize.html',
+        schema=schema,
+        table_name=table_name,
+        columns=columns,
+        rows=rows,
+        materials=materials,
+    )
 
 @bp.route('/run', methods=['POST'])
 @login_required
 def run():
-    try:
-        result = run_full_optimization()
-    except Exception as exc:
-        return jsonify(error=str(exc)), 400
-    if result is None:
-        return jsonify(error='Optimization failed'), 400
-    return jsonify(result)
+    import json
+
+    materials_raw = request.form.get('materials')
+    constraints_raw = request.form.get('constraints')
+
+    material_ids = json.loads(materials_raw) if materials_raw else None
+    constr = json.loads(constraints_raw) if constraints_raw else None
+
+    job_id = str(uuid4())
+    progress = {"total": 0, "done": 0}
+    _jobs[job_id] = {"progress": progress, "result": None, "error": None}
+
+    def worker():
+        try:
+            res = run_full_optimization(
+                material_ids=material_ids,
+                constraints=[(int(c['id']), c['op'], float(c['val'])) for c in constr] if constr else None,
+                progress=progress,
+            )
+            _jobs[job_id]["result"] = res
+        except Exception as exc:
+            _jobs[job_id]["error"] = str(exc)
+        finally:
+            progress["done"] = progress.get("total", 0)
+
+    Thread(target=worker, daemon=True).start()
+
+    return jsonify(job_id=job_id)
+
+
+@bp.route('/progress/<job_id>', methods=['GET'])
+@login_required
+def progress(job_id: str):
+    job = _jobs.get(job_id)
+    if not job:
+        return jsonify(error='invalid job'), 404
+    data = dict(job['progress'])
+    if job['result'] is not None:
+        data['result'] = job['result']
+    if job['error'] is not None:
+        data['error'] = job['error']
+    return jsonify(data)

--- a/app/static/optimize.js
+++ b/app/static/optimize.js
@@ -2,38 +2,171 @@ const form = document.getElementById('opt-form');
 const runBtn = document.getElementById('run');
 const spinner = document.getElementById('spinner');
 const resultDiv = document.getElementById('result');
+const progressDiv = document.getElementById('progress');
+const progressUrl = progressDiv.dataset.url || 'progress/';
+let progressTimer = null;
+let currentJob = null;
+const materials = JSON.parse(document.getElementById('materials-data').textContent);
+const addConstrBtn = document.getElementById('add-constr');
+const constrBody = document.getElementById('constraints-body');
+
+function fetchProgress() {
+  if (!currentJob) return;
+  fetch(progressUrl + currentJob, { credentials: 'same-origin' })
+    .then(r => r.json())
+    .then(d => {
+      if (d.total > 0) {
+        const pct = ((d.done / d.total) * 100).toFixed(2);
+        progressDiv.textContent = `Прогрес: ${pct}% (${d.done}/${d.total})`;
+      }
+      if (d.result || d.error) {
+        clearInterval(progressTimer);
+        progressTimer = null;
+        spinner.classList.add('d-none');
+        runBtn.disabled = false;
+        if (d.result) {
+          showResult(d.result);
+        } else {
+          alert(d.error || 'Грешка при оптимизацията');
+        }
+        currentJob = null;
+      }
+    })
+    .catch(() => {});
+}
+
+// prevent form submission when pressing Enter
+form.addEventListener('submit', e => e.preventDefault());
+
+function getSelectedIds() {
+  return Array.from(document.querySelectorAll('.use-chk:checked')).map(c =>
+    parseInt(c.value)
+  );
+}
+
+function updateConstraintOptions() {
+  const ids = getSelectedIds();
+  const rows = Array.from(constrBody.querySelectorAll('tr'));
+  rows.forEach(row => {
+    const sel = row.querySelector('.con-mat');
+    const current = parseInt(sel.value);
+    // remove options for unchecked materials
+    Array.from(sel.options).forEach(o => {
+      const val = parseInt(o.value);
+      if (!ids.includes(val)) {
+        if (val === current) {
+          row.remove();
+        }
+        o.remove();
+      }
+    });
+    // add options for newly checked materials
+    ids.forEach(id => {
+      if (!sel.querySelector(`option[value="${id}"]`)) {
+        const m = materials.find(mm => mm.id === id);
+        if (m) {
+          const opt = document.createElement('option');
+          opt.value = id;
+          opt.textContent = m.name;
+          sel.appendChild(opt);
+        }
+      }
+    });
+    if (!sel.options.length) {
+      row.remove();
+    } else if (!ids.includes(current)) {
+      sel.value = sel.options[0].value;
+    }
+  });
+}
+
+document.querySelectorAll('.use-chk').forEach(chk =>
+  chk.addEventListener('change', updateConstraintOptions)
+);
+
+// initial setup
+updateConstraintOptions();
+
+addConstrBtn.addEventListener('click', () => {
+  const ids = getSelectedIds();
+  if (!ids.length) {
+    return;
+  }
+  const tr = document.createElement('tr');
+  const td1 = document.createElement('td');
+  const sel = document.createElement('select');
+  sel.className = 'con-mat';
+  ids.forEach(id => {
+    const m = materials.find(mm => mm.id === id);
+    if (m) {
+      const o = document.createElement('option');
+      o.value = id;
+      o.textContent = m.name;
+      sel.appendChild(o);
+    }
+  });
+  td1.appendChild(sel);
+  const td2 = document.createElement('td');
+  const op = document.createElement('select');
+  op.className = 'con-op';
+  ['>','<','='].forEach(s => {
+    const opt = document.createElement('option');
+    opt.value = s;
+    opt.textContent = s;
+    op.appendChild(opt);
+  });
+  td2.appendChild(op);
+  const td3 = document.createElement('td');
+  const val = document.createElement('input');
+  val.type = 'number';
+  val.min = '0';
+  val.max = '1';
+  val.step = 'any';
+  val.className = 'con-val';
+  td3.appendChild(val);
+  tr.appendChild(td1);
+  tr.appendChild(td2);
+  tr.appendChild(td3);
+  constrBody.appendChild(tr);
+});
 
 runBtn.addEventListener('click', e => {
   e.preventDefault();
-  const formData = new FormData(form);
+  const formData = new FormData();
+  formData.append('csrf_token', form.querySelector('input[name="csrf_token"]').value);
+  const ids = getSelectedIds();
+  const constr = Array.from(constrBody.querySelectorAll('tr')).map(tr => ({
+    id: parseInt(tr.querySelector('.con-mat').value),
+    op: tr.querySelector('.con-op').value,
+    val: parseFloat(tr.querySelector('.con-val').value || 0)
+  }));
+  formData.append('materials', JSON.stringify(ids));
+  formData.append('constraints', JSON.stringify(constr));
   runBtn.disabled = true;
   resultDiv.classList.add('d-none');
+  progressDiv.textContent = '';
   spinner.classList.remove('d-none');
   fetch(form.action, {
     method: 'POST',
     body: formData,
     credentials: 'same-origin'
   })
-    .then(r =>
-      r
-        .json()
-        .then(data => {
-          if (!r.ok || data.error) {
-            throw new Error(data.error || r.status);
-          }
-          return data;
-        })
-    )
-    .then(showResult)
+    .then(r => r.json())
+    .then(data => {
+      if (!data.job_id) {
+        throw new Error(data.error || 'Невалиден отговор');
+      }
+      currentJob = data.job_id;
+      progressTimer = setInterval(fetchProgress, 2000);
+      fetchProgress();
+    })
     .catch(err => {
       console.error('Optimization error', err);
       alert(err.message || 'Грешка при оптимизацията.');
-
-    })
-    .finally(() => {
       spinner.classList.add('d-none');
       runBtn.disabled = false;
     });
+  // cleanup handled in fetchProgress when job finishes
 });
 
 function showResult(res) {
@@ -63,3 +196,4 @@ function showResult(res) {
     console.error('Chart.js not loaded');
   }
 }
+

--- a/app/templates/optimize.html
+++ b/app/templates/optimize.html
@@ -9,12 +9,43 @@
 
 <form id="opt-form" action="{{ url_for('optimize_bp.run') }}" method="post">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+  <table class="table table-striped" id="materials-table">
+    <thead>
+      <tr>
+        {% for col in columns %}
+          <th>{{ col == 'use' and 'Избор' or col }}</th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in rows %}
+        <tr>
+          <td><input type="checkbox" class="use-chk" value="{{ row['id'] }}" checked></td>
+          {% for col in columns[1:] %}
+            <td>{{ row[col] }}</td>
+          {% endfor %}
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <div class="mb-3">
+    <h5>Ограничения</h5>
+    <table class="table table-sm" id="constraints-table">
+      <thead><tr><th>Материал</th><th>Знак</th><th>Стойност</th></tr></thead>
+      <tbody id="constraints-body"></tbody>
+    </table>
+    <button type="button" id="add-constr" class="btn btn-secondary">Добави ограничение</button>
+  </div>
+
   <button id="run" type="button" class="btn btn-primary">Стартирай</button>
   <div id="spinner" class="d-none mt-2">
     <div class="spinner-border" role="status">
       <span class="visually-hidden">Изчакване...</span>
     </div>
   </div>
+  <div id="progress" data-url="{{ url_for('optimize_bp.progress', job_id='') }}" class="mt-2"></div>
 </form>
 
 <div id="result" class="d-none">
@@ -29,6 +60,9 @@
   <canvas id="chart" width="600" height="300"></canvas>
 </div>
 
+<script id="materials-data" type="application/json">
+  {{ materials|tojson }}
+</script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="{{ url_for('static', filename='optimize.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- run optimization in a background thread and track job progress
- expose job progress and result via `/progress/<job_id>`
- adapt frontend to start jobs and poll progress
- support custom progress dict in optimization routine

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b7aef22f48328a6d4a6f8db33672a