### PR TITLE
Save optimization results and show results page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -107,11 +107,13 @@ def create_app():
     from .routes_admin     import bp as admin_bp
     from .routes_materials import bp as materials_bp
     from .routes_optimize  import bp as optimize_bp
+    from .routes_results   import bp as results_bp
 
     app.register_blueprint(auth_bp,      url_prefix="/auth")
     app.register_blueprint(admin_bp,     url_prefix="/admin")
     app.register_blueprint(materials_bp)             # no prefix
     app.register_blueprint(optimize_bp,   url_prefix="/optimize")
+    app.register_blueprint(results_bp)               # /results
 
     # ── Root and favicon ─────────────────────────────────────────────────────
     @app.route("/")

--- a/app/models.py
+++ b/app/models.py
@@ -53,3 +53,12 @@ class MaterialGrit(db.Model):
     #    table = Table('materials_grit', meta, autoload_with=db.get_engine(), schema='main')
     #
     # and then reference table.c['0.12'], etc.
+
+
+class ResultsRecipe(db.Model):
+    __tablename__ = "results_recipe"
+
+    id = db.Column(db.Integer, primary_key=True)
+    dateref = db.Column(db.DateTime, nullable=False, server_default=db.func.now())
+    mse = db.Column(db.Float, nullable=False)
+    materials = db.Column(db.JSON, nullable=False)  # list of {name, percent}

--- a/app/optimize.py
+++ b/app/optimize.py
@@ -380,6 +380,7 @@ def run_full_optimization(
     return {
         # Convert NumPy integer IDs to plain Python ints for JSON serialization  csscdcdcscsd
         'material_ids': [int(ids[i]) for i in combo],
+        'material_names': [names[i] for i in combo],
         'weights':      weights.tolist(),
         'best_mse':     mse,
         'prop_columns': prop_cols,

--- a/app/routes_optimize.py
+++ b/app/routes_optimize.py
@@ -3,8 +3,11 @@ from flask_login import login_required, current_user
 from threading import Thread
 from uuid import uuid4
 
+from sqlalchemy import text
+
 from . import db
 from .optimize import run_full_optimization, _get_materials_table
+from .models import ResultsRecipe
 
 bp = Blueprint('optimize_bp', __name__)
 
@@ -55,6 +58,10 @@ def run():
     def worker():
         with app.app_context():
             try:
+                if schema:
+                    db.session.execute(text(f"SET search_path TO {schema}, main"))
+                else:
+                    db.session.execute(text("SET search_path TO main"))
                 res = run_full_optimization(
                     schema=schema,
                     material_ids=material_ids,
@@ -62,6 +69,15 @@ def run():
                     progress=progress,
                     user_id=user_id,
                 )
+                if res is not None:
+                    materials = [
+                        {"name": res["material_names"][i], "percent": res["weights"][i]}
+                        for i in range(len(res["material_ids"]))
+                    ]
+                    db.session.add(
+                        ResultsRecipe(mse=res["best_mse"], materials=materials)
+                    )
+                    db.session.commit()
                 _jobs[job_id]["result"] = res
             except Exception as exc:
                 _jobs[job_id]["error"] = str(exc)

--- a/app/routes_results.py
+++ b/app/routes_results.py
@@ -1,0 +1,21 @@
+from flask import Blueprint, render_template
+from flask_login import login_required
+from .models import ResultsRecipe
+
+bp = Blueprint('results', __name__)
+
+@bp.route('/results')
+@login_required
+def page():
+    rows = ResultsRecipe.query.order_by(ResultsRecipe.dateref.desc()).all()
+    results = [
+        {
+            'id': r.id,
+            'dateref': r.dateref,
+            'mse': r.mse,
+            'materials': r.materials,
+            'names': ', '.join(m['name'] for m in r.materials)
+        }
+        for r in rows
+    ]
+    return render_template('results.html', results=results)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,6 +21,7 @@
             <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.manage_users') }}">Manage Users</a></li>
           {% endif %}
           <li class="nav-item"><a class="nav-link" href="{{ url_for('optimize_bp.page') }}">Optimize</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('results.page') }}">Results</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a></li>
         {% else %}
           <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.login') }}">Login</a></li>

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Results</h1>
+<table class="table table-hover">
+  <thead>
+    <tr>
+      <th>Date & Time</th>
+      <th>MSE</th>
+      <th>Materials</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for r in results %}
+    <tr class="accordion-toggle" data-bs-toggle="collapse" data-bs-target="#res-{{ r.id }}">
+      <td>{{ r.dateref }}</td>
+      <td>{{ '%.6f'|format(r.mse) }}</td>
+      <td>{{ r.names }}</td>
+    </tr>
+    <tr id="res-{{ r.id }}" class="collapse">
+      <td colspan="3">
+        <ul class="mb-0">
+          {% for m in r.materials %}
+          <li>{{ m.name }}: {{ (m.percent * 100)|round(2) }}%</li>
+          {% endfor %}
+        </ul>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- align `results_recipe` table with `DateRef`, `mse`, and `materials` columns
- store optimization outputs into each client's schema and list them ordered by date on a Results page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68909350a6908328b4478ba54ff5a953