### PR TITLE
Handle wrapped optimization responses

### DIFF
--- a/app/routes_optimize.py
+++ b/app/routes_optimize.py
@@ -1,16 +1,21 @@
-from flask import Blueprint, render_template, jsonify, request
+from flask import Blueprint, render_template, jsonify, request, session
 from flask_login import login_required
+from threading import Thread
+from uuid import uuid4
 
 from . import db
 from .optimize import run_full_optimization, _get_materials_table
 
 bp = Blueprint('optimize_bp', __name__)
 
+# simple in-memory job store
+_jobs: dict[str, dict] = {}
+
 @bp.route('', methods=['GET'])
 @login_required
 def page():
-    tbl = _get_materials_table()
-    schema = tbl.schema or 'public'
+    schema = session.get('schema', 'main')
+    tbl = _get_materials_table(schema)
     table_name = tbl.name
     rows = db.session.execute(tbl.select()).mappings().all()
     cols = list(tbl.columns.keys())
@@ -39,13 +44,38 @@ def run():
     if not material_ids:
         return jsonify(error="No materials selected"), 400
 
-    try:
-        result = run_full_optimization(
-            material_ids=material_ids,
-            constraints=[(int(c['id']), c['op'], float(c['val'])) for c in constr] if constr else None,
-        )
-    except Exception as exc:
-        return jsonify(error=str(exc)), 400
-    if result is None:
-        return jsonify(error='Optimization failed'), 400
-    return jsonify(result)
+    job_id = uuid4().hex
+    # start with a dummy total > 0 so the UI knows the job is in progress
+    progress = {"total": 1, "done": 0}
+    _jobs[job_id] = {"progress": progress, "result": None, "error": None}
+
+    def worker():
+        try:
+            result = run_full_optimization(
+                material_ids=material_ids,
+                constraints=[(int(c['id']), c['op'], float(c['val'])) for c in constr] if constr else None,
+            )
+            _jobs[job_id]["result"] = result
+        except Exception as exc:
+            _jobs[job_id]["error"] = str(exc)
+        finally:
+            progress["done"] = progress["total"]
+
+    Thread(target=worker, daemon=True).start()
+    return jsonify(job_id=job_id)
+
+
+@bp.route('/progress')
+@login_required
+def progress():
+    job_id = request.args.get('job_id')
+    job = _jobs.get(job_id)
+    if not job:
+        return jsonify(error="Unknown job"), 404
+    prog = job["progress"]
+    data = {"total": prog["total"], "done": prog["done"]}
+    if job["error"]:
+        data["error"] = job["error"]
+    if job["result"] is not None:
+        data["result"] = job["result"]
+    return jsonify(data)

--- a/app/static/optimize.js
+++ b/app/static/optimize.js
@@ -144,19 +144,65 @@ runBtn.addEventListener('click', e => {
           return data;
         })
     )
-    .then(showResult)
+    .then(data => {
+      if (data.job_id) {
+        pollProgress(data.job_id);
+      } else {
+        showResult(data);
+        spinner.classList.add('d-none');
+        runBtn.disabled = false;
+      }
+    })
     .catch(err => {
       console.error('Optimization error', err);
       alert(err.message || 'Optimization error.');
-
-    })
-    .finally(() => {
       spinner.classList.add('d-none');
       runBtn.disabled = false;
     });
 });
 
+function pollProgress(jobId) {
+  fetch(`/optimize/progress?job_id=${jobId}`, { credentials: 'same-origin' })
+    .then(r => r.json())
+    .then(data => {
+      if (data.error) {
+        throw new Error(data.error);
+      }
+      if (data.total === 0 && data.done === 0) {
+        setTimeout(() => pollProgress(jobId), 500);
+        return;
+      }
+      if (data.done < data.total || !data.result) {
+        setTimeout(() => pollProgress(jobId), 500);
+        return;
+      }
+      showResult(data.result);
+      spinner.classList.add('d-none');
+      runBtn.disabled = false;
+    })
+    .catch(err => {
+      console.error('Optimization error', err);
+      alert(err.message || 'Optimization error.');
+      spinner.classList.add('d-none');
+      runBtn.disabled = false;
+    });
+}
+
 function showResult(res) {
+  // some backends may wrap or stringify the payload inside a `result` field
+  if (res && res.result !== undefined) {
+    if (typeof res.result === 'string') {
+      try {
+        res = JSON.parse(res.result);
+      } catch (e) {
+        console.error('Failed to parse result string', e, res.result);
+        alert('Invalid optimization response.');
+        return;
+      }
+    } else if (res.result && typeof res.result === 'object') {
+      res = res.result;
+    }
+  }
   if (!res || !Array.isArray(res.material_ids) || !Array.isArray(res.weights)) {
     alert(res && res.error ? res.error : 'Invalid optimization response.');
     console.error('Invalid response', res);


### PR DESCRIPTION
## Summary
- Initialize optimization jobs with a dummy `total` so early progress polls don't look finished
- Add progress endpoint and client-side polling that retries on `0/0` progress before displaying results
- Import Flask `session` and use it when loading the Optimize page to prevent a NameError

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890a64ab7fc832881616202913ca19a