### PR TITLE
Fix undefined progress reference

### DIFF
--- a/app/optimize.py
+++ b/app/optimize.py
@@ -334,7 +334,7 @@ def run_full_optimization(
     mse_threshold: float | None = 0.0004,
     material_ids: Optional[list[int]] = None,
     constraints: Optional[list[tuple[int, str, float]]] = None,
-
+    progress: Optional[dict] = None,
     user_id: Optional[int] = None,
 ):
     """Load materials and search for the optimal mix."""

--- a/app/routes_optimize.py
+++ b/app/routes_optimize.py
@@ -66,6 +66,7 @@ def run():
                     schema=schema,
                     material_ids=material_ids,
                     constraints=[(int(c['id']), c['op'], float(c['val'])) for c in constr] if constr else None,
+                    progress=progress,
                     user_id=user_id,
                 )
                 _jobs[job_id]["result"] = result


### PR DESCRIPTION
## Summary
- allow `run_full_optimization` to accept a progress dict instead of referencing an undefined name
- propagate request progress tracking to the optimizer worker

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890ba141bf083288dedfe543dff8fb8