### PR TITLE
Ensure default client and admin user via script

### DIFF
--- a/create_admin.py
+++ b/create_admin.py
@@ -1,14 +1,31 @@
-from app import create_app, db, bcrypt
-from app.models import User
+"""Utility script to ensure an admin user and default client exist."""
 
-app = create_app()
-with app.app_context():
-    if User.query.filter_by(username="admin").first():
-        print("Admin already exists.")
-    else:
-        admin = User(username="admin", role="admin")
-        admin.set_password("admin")
-        db.session.add(admin)
-        db.session.commit()
-        print("Admin created successfully.")
+from app import create_app, db
+from app.models import Client, User
+
+
+def main() -> None:
+    app = create_app()
+    with app.app_context():
+        # ensure a default client for operators
+        if not Client.query.filter_by(name="Default").first():
+            client = Client(name="Default", schema_name="main")
+            db.session.add(client)
+            db.session.commit()
+            print("Default client created.")
+        else:
+            print("Default client already exists.")
+
+        if User.query.filter_by(username="admin").first():
+            print("Admin already exists.")
+        else:
+            admin = User(username="admin", role="admin")
+            admin.set_password("admin")
+            db.session.add(admin)
+            db.session.commit()
+            print("Admin created successfully.")
+
+
+if __name__ == "__main__":
+    main()
 


### PR DESCRIPTION
## Summary
- ensure a default client record exists before creating admin user
- wrap admin creation logic in a `main()` function with an executable entry point

## Testing
- `python -m py_compile create_admin.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689981c364f48328a20119f5a3accba1