### PR TITLE
feat: show optimization timing

### DIFF
--- a/app/optimize.py
+++ b/app/optimize.py
@@ -349,6 +349,12 @@ def run_full_optimization(
     # compute the mixed profile using the chosen materials
     mixed = weights.dot(values[list(combo)])
 
+    # replace NaN/Inf values so JSON serialization doesn't fail
+    weights = np.nan_to_num(weights, nan=0.0, posinf=0.0, neginf=0.0)
+    mixed = np.nan_to_num(mixed, nan=0.0, posinf=0.0, neginf=0.0)
+    target = np.nan_to_num(target, nan=0.0, posinf=0.0, neginf=0.0)
+    mse = float(np.nan_to_num(mse, nan=0.0, posinf=0.0, neginf=0.0))
+
     return {
         # Convert NumPy integer IDs to plain Python ints for JSON serialization
         'material_ids': [int(ids[i]) for i in combo],

--- a/app/routes_materials.py
+++ b/app/routes_materials.py
@@ -154,3 +154,20 @@ def delete_rows():
         db.session.commit()
         flash(f"Deleted {len(ids)} rows.", "success")
     return redirect(url_for("materials.page_materials"))
+
+
+@bp.route("/materials/delete-columns", methods=["POST"])
+@login_required
+def delete_columns():
+    tbl = get_materials_table()
+    keep = {"id", "material_name"}
+    cols = [c for c in tbl.columns.keys() if c not in keep]
+    for col in cols:
+        ddl = text(
+            f'ALTER TABLE "{tbl.schema}"."{tbl.name}" DROP COLUMN "{col}"'
+        )
+        db.session.execute(ddl)
+    if cols:
+        db.session.commit()
+        flash(f"Deleted {len(cols)} columns.", "success")
+    return redirect(url_for("materials.page_materials"))

--- a/app/routes_optimize.py
+++ b/app/routes_optimize.py
@@ -37,37 +37,37 @@ def page():
 def run():
     import json
 
-    materials_raw = request.form.get('materials')
-    constraints_raw = request.form.get('constraints')
-    schema = request.form.get('schema') or session.get('schema')
-
-    material_ids = json.loads(materials_raw) if materials_raw else None
-    constr = json.loads(constraints_raw) if constraints_raw else None
-
-    if not material_ids:
-        return jsonify(error="No materials selected"), 400
-
-    schema = session.get('schema', 'main')
-    user_id = current_user.id
-
     try:
+        materials_raw = request.form.get('materials')
+        constraints_raw = request.form.get('constraints')
+        schema = request.form.get('schema') or session.get('schema')
+
+        material_ids = json.loads(materials_raw) if materials_raw else None
+        constr = json.loads(constraints_raw) if constraints_raw else None
+
+        if not material_ids:
+            return jsonify(error="No materials selected"), 400
+
+        schema = session.get('schema', 'main')
+        user_id = current_user.id
+
         result = run_full_optimization(
             schema=schema,
             material_ids=material_ids,
             constraints=[(int(c['id']), c['op'], float(c['val'])) for c in constr] if constr else None,
             user_id=user_id,
         )
+        if not result:
+            raise RuntimeError("Optimization failed")
+
+        materials = [
+            {"name": name, "percent": float(weight)}
+            for name, weight in zip(result["material_names"], result["weights"])
+        ]
+        db.session.add(ResultsRecipe(mse=result["best_mse"], materials=materials))
+        db.session.commit()
+
+        return jsonify(result)
     except Exception as exc:
+        db.session.rollback()
         return jsonify(error=str(exc)), 500
-
-    if not result:
-        return jsonify(error="Optimization failed"), 500
-
-    materials = [
-        {"name": name, "percent": float(weight)}
-        for name, weight in zip(result["material_names"], result["weights"])
-    ]
-    db.session.add(ResultsRecipe(mse=result["best_mse"], materials=materials))
-    db.session.commit()
-
-    return jsonify(result)

--- a/app/static/optimize.js
+++ b/app/static/optimize.js
@@ -7,6 +7,12 @@ const addConstrBtn = document.getElementById('add-constr');
 const constrBody = document.getElementById('constraints-body');
 const selectAllBtn = document.getElementById('select-all');
 const unselectAllBtn = document.getElementById('unselect-all');
+const estSpan = document.getElementById('est-time');
+const elapsedSpan = document.getElementById('elapsed-time');
+const elapsedWrap = document.getElementById('elapsed-wrap');
+
+const MAX_COMBO = 7; // should mirror backend
+const SECONDS_PER_COMBO = 0.15;
 
 // prevent form submission when pressing Enter
 form.addEventListener('submit', e => e.preventDefault());
@@ -15,6 +21,38 @@ function getSelectedIds() {
   return Array.from(document.querySelectorAll('.use-chk:checked')).map(c =>
     parseInt(c.value)
   );
+}
+
+function nCr(n, r) {
+  if (r > n) return 0;
+  let res = 1;
+  for (let i = 1; i <= r; i++) {
+    res = (res * (n - r + i)) / i;
+  }
+  return res;
+}
+
+function formatDuration(sec) {
+  const s = Math.round(sec);
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const rem = s % 60;
+  const parts = [];
+  if (h) parts.push(`${h}h`);
+  if (m || h) parts.push(`${m}m`);
+  parts.push(`${rem}s`);
+  return parts.join(' ');
+}
+
+function updateEstimate() {
+  const n = getSelectedIds().length;
+  const max = Math.min(MAX_COMBO, n);
+  let combos = 0;
+  for (let r = 1; r <= max; r++) {
+    combos += nCr(n, r);
+  }
+  const secs = combos * SECONDS_PER_COMBO;
+  estSpan.textContent = `${formatDuration(secs)} (${combos} combos)`;
 }
 
 function updateConstraintOptions() {
@@ -51,6 +89,7 @@ function updateConstraintOptions() {
       sel.value = sel.options[0].value;
     }
   });
+  updateEstimate();
 }
 
 document.querySelectorAll('.use-chk').forEach(chk =>
@@ -129,6 +168,13 @@ runBtn.addEventListener('click', e => {
   runBtn.disabled = true;
   resultDiv.classList.add('d-none');
   spinner.classList.remove('d-none');
+  elapsedWrap.classList.remove('d-none');
+  let start = Date.now();
+  elapsedSpan.textContent = '0s';
+  const timer = setInterval(() => {
+    const secs = (Date.now() - start) / 1000;
+    elapsedSpan.textContent = formatDuration(secs);
+  }, 1000);
   fetch(form.action, {
     method: 'POST',
     body: formData,
@@ -136,8 +182,14 @@ runBtn.addEventListener('click', e => {
   })
     .then(r =>
       r
-        .json()
-        .then(data => {
+        .text()
+        .then(txt => {
+          let data;
+          try {
+            data = JSON.parse(txt);
+          } catch (e) {
+            throw new Error(txt || e.message);
+          }
           if (!r.ok || data.error) {
             throw new Error(data.error || r.status);
           }
@@ -146,14 +198,15 @@ runBtn.addEventListener('click', e => {
     )
     .then(data => {
       showResult(data);
-      spinner.classList.add('d-none');
-      runBtn.disabled = false;
     })
     .catch(err => {
       console.error('Optimization error', err);
       alert(err.message || 'Optimization error.');
+    })
+    .finally(() => {
       spinner.classList.add('d-none');
       runBtn.disabled = false;
+      clearInterval(timer);
     });
 });
 

--- a/app/templates/materials.html
+++ b/app/templates/materials.html
@@ -22,6 +22,7 @@
       <button type="button" id="mat-select-all" class="btn btn-sm btn-secondary">Select All</button>
       <button type="button" id="mat-unselect-all" class="btn btn-sm btn-secondary">Unselect All</button>
       <button type="submit" id="delete-rows" class="btn btn-sm btn-danger">Delete rows</button>
+      <button type="submit" id="delete-cols" class="btn btn-sm btn-danger" formaction="{{ url_for('materials.delete_columns') }}">Delete Columns</button>
     </div>
     <table class="table table-striped" id="materials-table">
       <thead>

--- a/app/templates/optimize.html
+++ b/app/templates/optimize.html
@@ -50,6 +50,10 @@
       <span class="visually-hidden">Working...</span>
     </div>
   </div>
+  <div id="time-info" class="mt-3 p-3 bg-light rounded">
+    <div class="small"><strong>Estimated time:</strong> <span id="est-time">-</span></div>
+    <div id="elapsed-wrap" class="small d-none"><strong>Elapsed:</strong> <span id="elapsed-time">0s</span></div>
+  </div>
 </form>
 
 <div id="result" class="d-none">


### PR DESCRIPTION
## Summary
- show estimated time for evaluating combinations
- display elapsed time during optimization run
- allow removing all material columns except `material_name` and `id`
- sanitize optimization output so frontend always receives valid JSON
- ensure optimization endpoint always returns JSON and gracefully handles errors

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689af0e0f58c8328a51662fd44e3bcd7